### PR TITLE
add function and name

### DIFF
--- a/manuscript/building_the_html.md
+++ b/manuscript/building_the_html.md
@@ -26,6 +26,7 @@ The path and filename of the CSS template to use.
 .\New-HTMLSystemReport -ComputerName ONE,TWO `
                        -Path C:\Reports\ 
 #>
+function New-HTMLSystemReport
 [CmdletBinding()]
 param(
     [Parameter(Mandatory=$True,


### PR DESCRIPTION
Add Function statement and name.  Kept the name consistent with the help documentation. @concentrateddon I couldn't get this function to run without adding the "function" statement and name.