### PR TITLE
Fix links to pages

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,10 +1,10 @@
 # Table of contents
 
 * [ReadMe](README.md)
-* [Introduction](introduction.md)
-* [HTML Report Basics](html-report-basics.md)
-* [Gathering the Information](gathering-the-information.md)
-* [Building the HTML](building-the-html.md)
-* [Combining HTML Reports and a GUI Application](combining-html-reports-and-a-gui-application.md)
-* [Contacting Me](contacting-me.md)
+* [Introduction](manuscript/introduction.md)
+* [HTML Report Basics](manuscript/html-report-basics.md)
+* [Gathering the Information](manuscript/gathering-the-information.md)
+* [Building the HTML](manuscript/building-the-html.md)
+* [Combining HTML Reports and a GUI Application](manuscript/combining-html-reports-and-a-gui-application.md)
+* [Contacting Me](manuscript/contacting-me.md)
 


### PR DESCRIPTION
Links were pointing to the root of the repository rather than the manuscript directory. This is high visibility b/c all links on the web site at https://devops-collective-inc.gitbook.io/creating-html-reports-in-powershell/ 
are currently showing as empty pages.